### PR TITLE
fix for nextcloud auth manager

### DIFF
--- a/servers/revad/revanc1.toml
+++ b/servers/revad/revanc1.toml
@@ -107,7 +107,7 @@ mock_http = false
 [grpc.services.authprovider]
 auth_manager = "nextcloud"
 
-[grpc.services.authprovider.drivers.nextcloud]
+[grpc.services.authprovider.auth_managers.nextcloud]
 endpoint = "https://einstein:relativity@nc1.docker/index.php/apps/sciencemesh/"
 mock_http = false
 

--- a/servers/revad/revanc2.toml
+++ b/servers/revad/revanc2.toml
@@ -107,7 +107,7 @@ mock_http = false
 [grpc.services.authprovider]
 auth_manager = "nextcloud"
 
-[grpc.services.authprovider.drivers.nextcloud]
+[grpc.services.authprovider.auth_managers.nextcloud]
 endpoint = "https://marie:radioactivity@nc2.docker/index.php/apps/sciencemesh/"
 mock_http = false
 


### PR DESCRIPTION
This fixes a typo in the revanc1.toml and revanc2.toml that prevents the auth manager from connecting to nextcloud.