### PR TITLE
Attempt to install reva-sharees branch of owncloud/core

### DIFF
--- a/servers/owncloud/Dockerfile
+++ b/servers/owncloud/Dockerfile
@@ -1,10 +1,19 @@
 FROM apache-php
 RUN rm -rf /var/www/html
 USER www-data
-RUN wget https://download.owncloud.org/community/owncloud-complete-20210721.tar.bz2
-RUN tar -xjf ./owncloud-complete-20210721.tar.bz2
-RUN mv owncloud html
+RUN git clone --depth=1 --branch reva-sharees https://github.com/pondersource/core.git --recursive --shallow-submodules
+WORKDIR /var/www/core
+USER root
+RUN apt update && apt install -y composer curl dirmngr apt-transport-https lsb-release ca-certificates
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN apt install nodejs
+RUN npm install yarn
+USER www-data
+WORKDIR /var/www
+RUN mv core html
 WORKDIR /var/www/html
+RUN composer install
+RUN make install-nodejs-deps
 ENV PHP_MEMORY_LIMIT="512M"
 ADD init.sh /init.sh
 RUN git clone --depth=1 https://github.com/pondersource/oc-sciencemesh apps/sciencemesh

--- a/servers/owncloud/Dockerfile
+++ b/servers/owncloud/Dockerfile
@@ -7,7 +7,7 @@ USER root
 RUN apt update && apt install -y composer curl dirmngr apt-transport-https lsb-release ca-certificates
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt install nodejs
-RUN npm install yarn
+RUN npm install -g yarn
 USER www-data
 WORKDIR /var/www
 RUN mv core html


### PR DESCRIPTION
The oc-sciencemesh app relies on functionality from https://github.com/pondersource/core/tree/reva-sharees .
The current Dockerfile for owncloud installs owncloud/core from a tar file, we'll probably have to somehow compile from source in the Dockerfile.
